### PR TITLE
chore: remove unused imports across framework and tests

### DIFF
--- a/pytorch_segmentation_models_trainer/__init__.py
+++ b/pytorch_segmentation_models_trainer/__init__.py
@@ -33,4 +33,11 @@ from . import tools
 from . import custom_callbacks
 from . import dataset_distillation
 
-__all__ = ["dataset_loader", "model_loader", "tools", "utils", "dataset_distillation"]
+__all__ = [
+    "dataset_loader",
+    "model_loader",
+    "tools",
+    "utils",
+    "custom_callbacks",
+    "dataset_distillation",
+]

--- a/pytorch_segmentation_models_trainer/classic_ml/orchestrator.py
+++ b/pytorch_segmentation_models_trainer/classic_ml/orchestrator.py
@@ -10,7 +10,7 @@ sklearn-compatible classifier, and an optional
 
 import pickle
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import List, Tuple, Union
 
 import numpy as np
 

--- a/pytorch_segmentation_models_trainer/config_definitions/edl_config.py
+++ b/pytorch_segmentation_models_trainer/config_definitions/edl_config.py
@@ -26,7 +26,7 @@ directly in YAML files via the ``_target_`` mechanism.
 
 import logging
 from dataclasses import dataclass, field
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional
 
 from hydra.core.config_store import ConfigStore
 from omegaconf import MISSING

--- a/pytorch_segmentation_models_trainer/config_definitions/loss_config_definition.py
+++ b/pytorch_segmentation_models_trainer/config_definitions/loss_config_definition.py
@@ -21,7 +21,7 @@
 
 from dataclasses import dataclass, field
 import logging
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional
 
 import hydra
 from hydra.core.config_store import ConfigStore

--- a/pytorch_segmentation_models_trainer/config_definitions/train_config.py
+++ b/pytorch_segmentation_models_trainer/config_definitions/train_config.py
@@ -22,12 +22,10 @@
 from dataclasses import dataclass, field
 from typing import List, Optional, Any
 
-import torch
 from omegaconf import MISSING
 from pytorch_segmentation_models_trainer.config_definitions.loss_config_definition import (
     LossParamsConfig,
 )
-from pytorch_segmentation_models_trainer.model_loader.model import Model
 from pytorch_segmentation_models_trainer.config_definitions.dataset_config import (
     DatasetConfig,
 )

--- a/pytorch_segmentation_models_trainer/custom_callbacks/edl_callbacks.py
+++ b/pytorch_segmentation_models_trainer/custom_callbacks/edl_callbacks.py
@@ -31,7 +31,6 @@ EvidentialUncertaintyVisualizationCallback
 """
 
 import logging
-import os
 from pathlib import Path
 from typing import Optional
 

--- a/pytorch_segmentation_models_trainer/custom_models/edl_wrapper.py
+++ b/pytorch_segmentation_models_trainer/custom_models/edl_wrapper.py
@@ -48,7 +48,6 @@ Usage (Hydra config)::
 import logging
 from typing import Dict
 
-import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor

--- a/pytorch_segmentation_models_trainer/custom_models/generic_autoencoder.py
+++ b/pytorch_segmentation_models_trainer/custom_models/generic_autoencoder.py
@@ -3,7 +3,7 @@
 Generic Autoencoder combining SMP and Transformers.
 """
 
-from typing import Optional, Union, Tuple, List
+from typing import Optional
 import torch
 import torch.nn as nn
 import torch.nn.functional as F

--- a/pytorch_segmentation_models_trainer/custom_models/huggingface_models.py
+++ b/pytorch_segmentation_models_trainer/custom_models/huggingface_models.py
@@ -18,11 +18,10 @@
  ****
 """
 
-from typing import Optional, Tuple, Union
+from typing import Tuple, Union
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 
 from pytorch_segmentation_models_trainer.custom_models.transformer_adapters import (
     ModelOutputAdapter,

--- a/pytorch_segmentation_models_trainer/custom_models/terratorch_models.py
+++ b/pytorch_segmentation_models_trainer/custom_models/terratorch_models.py
@@ -40,7 +40,7 @@ Requires ``terratorch`` to be installed::
     pip install terratorch
 """
 
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Tuple
 
 import torch
 import torch.nn as nn

--- a/pytorch_segmentation_models_trainer/custom_models/timm_models.py
+++ b/pytorch_segmentation_models_trainer/custom_models/timm_models.py
@@ -38,7 +38,7 @@ that is *not* registered as an SMP encoder, or when you want fine-grained
 control over the decoder architecture.
 """
 
-from typing import List, Optional
+from typing import List
 
 import torch
 import torch.nn as nn

--- a/pytorch_segmentation_models_trainer/custom_models/upernet_dual_head.py
+++ b/pytorch_segmentation_models_trainer/custom_models/upernet_dual_head.py
@@ -23,7 +23,7 @@ Usage via Hydra YAML:
 
 import torch
 import torch.nn as nn
-from typing import Any, Callable, Dict, Optional, Sequence, Union
+from typing import Any, Callable, Dict, Optional, Union
 
 from segmentation_models_pytorch.base import (
     SegmentationHead,

--- a/pytorch_segmentation_models_trainer/custom_models/upernet_medoe.py
+++ b/pytorch_segmentation_models_trainer/custom_models/upernet_medoe.py
@@ -29,7 +29,7 @@ Usage via Hydra YAML:
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from segmentation_models_pytorch.base import SegmentationHead
 from segmentation_models_pytorch.base import initialization as init

--- a/pytorch_segmentation_models_trainer/custom_models/upernet_moe.py
+++ b/pytorch_segmentation_models_trainer/custom_models/upernet_moe.py
@@ -32,7 +32,6 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 from segmentation_models_pytorch.base import (
     SegmentationHead,
-    ClassificationHead,
 )
 from segmentation_models_pytorch.base import initialization as init
 from segmentation_models_pytorch.base import modules as md

--- a/pytorch_segmentation_models_trainer/dataset_loader/dataset.py
+++ b/pytorch_segmentation_models_trainer/dataset_loader/dataset.py
@@ -24,7 +24,6 @@ import hashlib
 import itertools
 import json
 import logging
-import math
 import os
 import rasterio
 from collections import OrderedDict
@@ -49,9 +48,6 @@ from pytorch_segmentation_models_trainer.utils.object_detection_utils import (
 )
 from pytorch_segmentation_models_trainer.utils.dataframe_utils import read_dataframe
 from torch.utils.data import Dataset
-
-import gc
-import kornia as K
 
 try:
     import fcntl
@@ -154,7 +150,6 @@ class AbstractDataset(Dataset):
         Returns:
             Dict[str, Any]: Loaded item.
         """
-        pass
 
     def get_path(self, idx: int, key: str = None, add_root_dir: bool = True):
         key = self.image_key if key is None else key

--- a/pytorch_segmentation_models_trainer/dataset_loader/ddoq_dataset.py
+++ b/pytorch_segmentation_models_trainer/dataset_loader/ddoq_dataset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple
 import torch
 from torch.utils.data import Dataset
 

--- a/pytorch_segmentation_models_trainer/dataset_loader/embedding_dataset.py
+++ b/pytorch_segmentation_models_trainer/dataset_loader/embedding_dataset.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
-import glob
 import json
 import logging
-import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 

--- a/pytorch_segmentation_models_trainer/dataset_loader/soft_label_dataset.py
+++ b/pytorch_segmentation_models_trainer/dataset_loader/soft_label_dataset.py
@@ -3,7 +3,7 @@
 
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 import albumentations as A
 import numpy as np
@@ -13,7 +13,6 @@ import torch
 
 from pytorch_segmentation_models_trainer.dataset_loader.dataset import (
     AbstractDataset,
-    load_augmentation_object,
 )
 
 logger = logging.getLogger(__name__)

--- a/pytorch_segmentation_models_trainer/dataset_loader/soft_label_windowed_dataset.py
+++ b/pytorch_segmentation_models_trainer/dataset_loader/soft_label_windowed_dataset.py
@@ -3,18 +3,14 @@
 
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Optional, Union
 
-import albumentations as A
 import numpy as np
 import pandas as pd
 import rasterio
 import rasterio.windows
 import torch
 
-from pytorch_segmentation_models_trainer.dataset_loader.dataset import (
-    load_augmentation_object,
-)
 from pytorch_segmentation_models_trainer.dataset_loader.soft_label_dataset import (
     SoftLabelDataset,
 )

--- a/pytorch_segmentation_models_trainer/domain_adaptation/base_method.py
+++ b/pytorch_segmentation_models_trainer/domain_adaptation/base_method.py
@@ -29,7 +29,6 @@ if TYPE_CHECKING:
         DomainAdaptationModel,
     )
 
-import torch
 import torch.nn as nn
 from torch import Tensor
 

--- a/pytorch_segmentation_models_trainer/domain_adaptation/callbacks/monitor_callback.py
+++ b/pytorch_segmentation_models_trainer/domain_adaptation/callbacks/monitor_callback.py
@@ -22,10 +22,9 @@
 from __future__ import annotations
 
 import logging
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 import torch
-import torch.nn.functional as F
 import pytorch_lightning as pl
 from pytorch_lightning.utilities.rank_zero import rank_zero_only
 from torch.utils.data import DataLoader

--- a/pytorch_segmentation_models_trainer/domain_adaptation/methods/dann.py
+++ b/pytorch_segmentation_models_trainer/domain_adaptation/methods/dann.py
@@ -22,7 +22,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Literal
 
 if TYPE_CHECKING:
     from pytorch_segmentation_models_trainer.model_loader.domain_adaptation_model import (

--- a/pytorch_segmentation_models_trainer/fine_tuning/lora_utils.py
+++ b/pytorch_segmentation_models_trainer/fine_tuning/lora_utils.py
@@ -45,9 +45,8 @@ All strategies log a parameter count summary via Python's ``logging`` module.
 """
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
-import torch
 import torch.nn as nn
 
 logger = logging.getLogger(__name__)

--- a/pytorch_segmentation_models_trainer/model_loader/co_teaching_model.py
+++ b/pytorch_segmentation_models_trainer/model_loader/co_teaching_model.py
@@ -8,7 +8,7 @@ other network considers low-loss (class-balanced selection).
 """
 
 import logging
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Optional
 
 import torch
 from hydra.utils import instantiate

--- a/pytorch_segmentation_models_trainer/model_loader/model.py
+++ b/pytorch_segmentation_models_trainer/model_loader/model.py
@@ -34,7 +34,6 @@ from pytorch_segmentation_models_trainer.utils.seed_utils import set_training_se
 from pytorch_segmentation_models_trainer.custom_losses.base_loss import MultiLoss
 from pytorch_segmentation_models_trainer.fine_tuning.lora_utils import (
     apply_fine_tuning_strategy,
-    is_peft_model,
 )
 from pytorch_segmentation_models_trainer.tools.tta.tta import (
     ROTATION_AUGMENTATIONS as _DEFAULT_TTA_AUGMENTATIONS,

--- a/pytorch_segmentation_models_trainer/model_loader/polygon_rnn_model.py
+++ b/pytorch_segmentation_models_trainer/model_loader/polygon_rnn_model.py
@@ -105,7 +105,6 @@ class PolygonRNNPLModel(Model):
         """Aggregate IoU across the validation epoch"""
         # Note: In Lightning 2.0+, you can use self.trainer.callback_metrics
         # or implement custom aggregation if needed
-        pass
 
     def evaluate_batch(self, batch, result):
         gt_polygon_list = polygonrnn_utils.get_vertex_list_from_batch_tensors(

--- a/pytorch_segmentation_models_trainer/model_loader/student_model.py
+++ b/pytorch_segmentation_models_trainer/model_loader/student_model.py
@@ -5,7 +5,6 @@ Inherits from the base Model class to maintain consistency with the framework.
 """
 
 import logging
-import torch
 import torch.nn.functional as F
 from pytorch_segmentation_models_trainer.model_loader.model import Model
 

--- a/pytorch_segmentation_models_trainer/tools/cli.py
+++ b/pytorch_segmentation_models_trainer/tools/cli.py
@@ -12,7 +12,6 @@ import click
 @click.group()
 def cli():
     """Command-line utilities for pytorch_segmentation_models_trainer."""
-    pass
 
 
 @cli.command("compute-stats")

--- a/pytorch_segmentation_models_trainer/tools/data_handlers/csv_to_parquet.py
+++ b/pytorch_segmentation_models_trainer/tools/data_handlers/csv_to_parquet.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import argparse
-import os
 import pandas as pd
 from pathlib import Path
 from tqdm import tqdm

--- a/pytorch_segmentation_models_trainer/tools/dataset_builder/sliding_window_builder.py
+++ b/pytorch_segmentation_models_trainer/tools/dataset_builder/sliding_window_builder.py
@@ -70,7 +70,6 @@ def _process_pair(
     mi: Optional[str],
 ) -> List[dict]:
     """Crop a single image/mask pair into sliding-window patches."""
-    import numpy as np
     import rasterio
     from rasterio.windows import Window, transform as window_transform
 

--- a/pytorch_segmentation_models_trainer/tools/dataset_builder/tile_dataset_builder.py
+++ b/pytorch_segmentation_models_trainer/tools/dataset_builder/tile_dataset_builder.py
@@ -83,9 +83,7 @@ def _process_image(
     import numpy as np
     import rasterio
     from rasterio.features import rasterize
-    from rasterio.transform import from_bounds
-    from rasterio.warp import transform_geom
-    from shapely.geometry import box, mapping
+    from shapely.geometry import mapping
 
     if not 0 <= background_value <= 255:
         raise ValueError("background_value must be in the uint8 range [0, 255]")

--- a/pytorch_segmentation_models_trainer/tools/detection/bbox_handler.py
+++ b/pytorch_segmentation_models_trainer/tools/detection/bbox_handler.py
@@ -27,7 +27,6 @@ import torch
 import copy
 from sahi.postprocess.combine import NMSPostprocess
 from sahi.postprocess.legacy.combine import PostprocessPredictions
-from sahi.annotation import BoundingBox, Category
 from sahi.postprocess.utils import calculate_box_union
 from sahi.prediction import ObjectPrediction
 

--- a/pytorch_segmentation_models_trainer/tools/evaluation/evaluation_pipeline.py
+++ b/pytorch_segmentation_models_trainer/tools/evaluation/evaluation_pipeline.py
@@ -31,9 +31,6 @@ from typing import Dict, Tuple
 from omegaconf import DictConfig, OmegaConf
 from tqdm import tqdm
 
-from pytorch_segmentation_models_trainer.tools.evaluation.csv_builder import (
-    DatasetCSVBuilder,
-)
 from pytorch_segmentation_models_trainer.tools.evaluation.gpu_distributor import (
     GPUDistributor,
 )

--- a/pytorch_segmentation_models_trainer/tools/evaluation/metrics_calculator.py
+++ b/pytorch_segmentation_models_trainer/tools/evaluation/metrics_calculator.py
@@ -2,8 +2,7 @@ import os
 import json
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
-from typing import Dict, List, Optional, Any
-from datetime import datetime
+from typing import Dict, Optional
 
 import numpy as np
 import pandas as pd
@@ -11,8 +10,7 @@ import torch
 import rasterio
 from rasterio.windows import Window, from_bounds
 from rasterio.coords import BoundingBox
-from tqdm import tqdm
-from omegaconf import DictConfig, OmegaConf
+from omegaconf import DictConfig
 from hydra.utils import instantiate
 
 import logging

--- a/pytorch_segmentation_models_trainer/tools/experiments_runner/experiments_runner.py
+++ b/pytorch_segmentation_models_trainer/tools/experiments_runner/experiments_runner.py
@@ -26,7 +26,7 @@ import os
 import secrets
 import statistics
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple
 
 from omegaconf import DictConfig, OmegaConf

--- a/pytorch_segmentation_models_trainer/tools/experiments_runner/optuna_runner.py
+++ b/pytorch_segmentation_models_trainer/tools/experiments_runner/optuna_runner.py
@@ -22,7 +22,7 @@ import json
 import logging
 import os
 import secrets
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 
 import optuna
 from omegaconf import DictConfig, OmegaConf

--- a/pytorch_segmentation_models_trainer/tools/inference/edl_inference_processor.py
+++ b/pytorch_segmentation_models_trainer/tools/inference/edl_inference_processor.py
@@ -41,20 +41,15 @@ Typical CLI usage (``predict.py`` detects EDL automatically)::
 """
 
 import logging
-import math
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Dict, Optional, Union
 
-import albumentations as A
-import cv2
 import numpy as np
 import rasterio
 import rasterio.transform
 import torch
 from pytorch_toolbelt.inference.tiles import ImageSlicer, TileMerger
-from pytorch_toolbelt.utils.torch_utils import image_to_tensor, to_numpy
-from torch.cuda.amp import autocast
-from torch.utils.data import DataLoader
+from pytorch_toolbelt.utils.torch_utils import to_numpy
 
 from pytorch_segmentation_models_trainer.tools.inference.inference_processors import (
     SingleImageInfereceProcessor,

--- a/pytorch_segmentation_models_trainer/tools/inference/inference_processors.py
+++ b/pytorch_segmentation_models_trainer/tools/inference/inference_processors.py
@@ -20,7 +20,6 @@
 """
 
 from collections import defaultdict
-from concurrent.futures.thread import ThreadPoolExecutor
 import logging
 import os
 import math
@@ -203,7 +202,6 @@ class AbstractInferenceProcessor(ABC):
         Returns:
             torch.Tensor: model inference
         """
-        pass
 
 
 class SingleImageInfereceProcessor(AbstractInferenceProcessor):

--- a/pytorch_segmentation_models_trainer/tools/inference/mc_dropout_inference_processor.py
+++ b/pytorch_segmentation_models_trainer/tools/inference/mc_dropout_inference_processor.py
@@ -59,7 +59,6 @@ from typing import Any, Dict, List, Optional
 import numpy as np
 import torch
 from pytorch_toolbelt.inference.tiles import ImageSlicer, TileMerger
-from pytorch_toolbelt.utils.torch_utils import to_numpy
 from torch.cuda.amp import autocast
 from torch.utils.data import DataLoader
 

--- a/pytorch_segmentation_models_trainer/tools/inference/sliding_window.py
+++ b/pytorch_segmentation_models_trainer/tools/inference/sliding_window.py
@@ -61,7 +61,7 @@ YAML example (Model config)::
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Callable, List, Optional, Tuple, Union
 
 import numpy as np
@@ -69,7 +69,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from pytorch_toolbelt.inference.tiles import ImageSlicer, TileMerger
-from pytorch_toolbelt.utils.torch_utils import image_to_tensor, to_numpy
+from pytorch_toolbelt.utils.torch_utils import image_to_tensor
 from torch.utils.data import DataLoader
 
 from pytorch_segmentation_models_trainer.tools.tta.tta import (

--- a/pytorch_segmentation_models_trainer/tools/kmeans/kmeans_calculator.py
+++ b/pytorch_segmentation_models_trainer/tools/kmeans/kmeans_calculator.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import torch
-import torch.nn as nn
 from typing import Optional, Union
 
 

--- a/pytorch_segmentation_models_trainer/tools/mask_building/mask_builder.py
+++ b/pytorch_segmentation_models_trainer/tools/mask_building/mask_builder.py
@@ -31,7 +31,6 @@ from typing import Any, List
 from omegaconf import MISSING, DictConfig
 from pytorch_segmentation_models_trainer.tools.data_handlers.raster_reader import (
     DatasetEntry,
-    MaskOutputType,
     RasterFile,
 )
 from pytorch_segmentation_models_trainer.tools.data_handlers.vector_reader import (

--- a/pytorch_segmentation_models_trainer/tools/mbtiles/__init__.py
+++ b/pytorch_segmentation_models_trainer/tools/mbtiles/__init__.py
@@ -4,3 +4,5 @@
 from pytorch_segmentation_models_trainer.tools.mbtiles.multiclass_mask_builder import (
     build_mbtiles_multiclass_masks,
 )
+
+__all__ = ["build_mbtiles_multiclass_masks"]

--- a/pytorch_segmentation_models_trainer/tools/polygonization/methods/active_skeletons.py
+++ b/pytorch_segmentation_models_trainer/tools/polygonization/methods/active_skeletons.py
@@ -37,7 +37,6 @@ from pytorch_segmentation_models_trainer.optimizers.poly_optimizers import (
 from pytorch_segmentation_models_trainer.utils.math_utils import compute_crossfield_uv
 from pytorch_segmentation_models_trainer.utils import (
     frame_field_utils,
-    math_utils,
     tensor_utils,
 )
 from pytorch_segmentation_models_trainer.tools.polygonization.skeletonize_tensor_tools import (

--- a/pytorch_segmentation_models_trainer/tools/polygonization/methods/simple.py
+++ b/pytorch_segmentation_models_trainer/tools/polygonization/methods/simple.py
@@ -25,7 +25,6 @@ from functools import partial
 
 import shapely.geometry
 import shapely.ops
-import skimage.io
 from pytorch_segmentation_models_trainer.tools.polygonization import polygonize_utils
 
 

--- a/pytorch_segmentation_models_trainer/tools/polygonization/polygonizer.py
+++ b/pytorch_segmentation_models_trainer/tools/polygonization/polygonizer.py
@@ -55,7 +55,6 @@ class TemplatePolygonizerProcessor(ABC):
         """Must be reimplemented in each child.
         self.polygonize_method must be set.
         """
-        pass
 
     def process(
         self,

--- a/pytorch_segmentation_models_trainer/tools/raster/vrt2tif.py
+++ b/pytorch_segmentation_models_trainer/tools/raster/vrt2tif.py
@@ -7,7 +7,6 @@ to a tiled, compressed GeoTIFF.
 
 from __future__ import annotations
 
-import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Optional, Tuple

--- a/pytorch_segmentation_models_trainer/tools/visualization/segmentation_vis.py
+++ b/pytorch_segmentation_models_trainer/tools/visualization/segmentation_vis.py
@@ -210,9 +210,6 @@ def create_segmentation_grid(
         """Resize pred to match gt shape if needed (simple nearest-neighbor)."""
         if pred_arr.shape == gt_arr.shape:
             return pred_arr
-        from rasterio.enums import Resampling
-        from rasterio.transform import from_bounds
-        import rasterio.warp as warp
 
         # Simple resize via zoom
         from scipy.ndimage import zoom

--- a/pytorch_segmentation_models_trainer/utils/__init__.py
+++ b/pytorch_segmentation_models_trainer/utils/__init__.py
@@ -1,2 +1,4 @@
 from . import math_utils
 from . import model_utils
+
+__all__ = ["math_utils", "model_utils"]

--- a/pytorch_segmentation_models_trainer/utils/dataframe_utils.py
+++ b/pytorch_segmentation_models_trainer/utils/dataframe_utils.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import os
 import pandas as pd
 from pathlib import Path
 from typing import Optional, Union

--- a/pytorch_segmentation_models_trainer/utils/tensor_utils.py
+++ b/pytorch_segmentation_models_trainer/utils/tensor_utils.py
@@ -24,7 +24,6 @@
 from typing import Dict
 import numpy as np
 import torch
-import kornia
 from kornia.filters.kernels import (
     get_diff_kernel2d,
     get_diff_kernel2d_2nd_order,

--- a/scripts/build_soft_labels.py
+++ b/scripts/build_soft_labels.py
@@ -23,7 +23,6 @@ from pytorch_segmentation_models_trainer.tools.soft_labels.build_soft_labels imp
 
 if __name__ == "__main__":
     import argparse
-    import sys
     from pathlib import Path
 
     parser = argparse.ArgumentParser(

--- a/tests/test_advanced_features.py
+++ b/tests/test_advanced_features.py
@@ -28,7 +28,7 @@ import rasterio
 from rasterio.transform import from_bounds
 import torch
 import torch.nn as nn
-from unittest.mock import Mock, MagicMock, patch
+from unittest.mock import Mock
 
 from pytorch_segmentation_models_trainer.custom_losses.loss import (
     GCBLLoss,

--- a/tests/test_band_combiner.py
+++ b/tests/test_band_combiner.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import numpy as np
-import pytest
 import rasterio
 from rasterio.transform import from_bounds
 

--- a/tests/test_build_mask.py
+++ b/tests/test_build_mask.py
@@ -22,36 +22,20 @@
 
 import ast
 import os
-import unittest
 from unittest.mock import MagicMock, patch
 import warnings
 
-import hydra
 import numpy as np
 import pandas as pd
 from hydra import compose, initialize
-from parameterized import parameterized
-from sqlalchemy import create_engine
-import psycopg2
 from pytorch_segmentation_models_trainer.build_mask import build_masks
-from pytorch_segmentation_models_trainer.tools.data_handlers.raster_reader import (
-    MaskOutputTypeEnum,
-    RasterFile,
-)
 from pytorch_segmentation_models_trainer.tools.data_handlers.vector_reader import (
     FileGeoDF,
-    GeomTypeEnum,
 )
 from pytorch_segmentation_models_trainer.tools.mask_building.mask_builder import (
-    MaskBuilder,
     TemplateMaskBuilder,
     build_destination_dirs,
     merge_csv_datasets,
-)
-from pytorch_segmentation_models_trainer.utils.os_utils import (
-    create_folder,
-    hash_file,
-    remove_folder,
 )
 
 current_dir = os.path.dirname(__file__)

--- a/tests/test_build_soft_labels.py
+++ b/tests/test_build_soft_labels.py
@@ -1640,7 +1640,6 @@ class TestRun:
         from pytorch_segmentation_models_trainer.tools.soft_labels.build_soft_labels import (
             run,
         )
-        import pandas as pd
 
         img_path, path_a, path_b, _, _ = same_res_setup
         csv_path = self._sources_csv(tmp_path, img_path, path_a, path_b)

--- a/tests/test_classic_ml_estimators.py
+++ b/tests/test_classic_ml_estimators.py
@@ -5,7 +5,6 @@ import sys
 from unittest.mock import MagicMock, patch
 
 import numpy as np
-import pytest
 import torch
 
 from pytorch_segmentation_models_trainer.classic_ml.estimators import (

--- a/tests/test_classic_ml_feature_engineering.py
+++ b/tests/test_classic_ml_feature_engineering.py
@@ -5,10 +5,7 @@ import sys
 from unittest.mock import MagicMock, patch
 
 import numpy as np
-import pytest
 
-import pytorch_segmentation_models_trainer.classic_ml as classic_ml_pkg
-import pytorch_segmentation_models_trainer.classic_ml.feature_engineering as fe
 from pytorch_segmentation_models_trainer.classic_ml.feature_engineering import (
     FeatureEngineeringPipeline,
     GaborFilterExtractor,

--- a/tests/test_classic_ml_orchestrator.py
+++ b/tests/test_classic_ml_orchestrator.py
@@ -1,13 +1,11 @@
 # -*- coding: utf-8 -*-
 """Tests for pytorch_segmentation_models_trainer.classic_ml.orchestrator."""
 
-import pickle
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import numpy as np
-import pytest
 
 from pytorch_segmentation_models_trainer.classic_ml.orchestrator import (
     ClassicMLOrchestrator,

--- a/tests/test_classic_ml_postprocessing.py
+++ b/tests/test_classic_ml_postprocessing.py
@@ -2,7 +2,7 @@
 """Tests for pytorch_segmentation_models_trainer.classic_ml.postprocessing."""
 
 import sys
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest

--- a/tests/test_cluster_centers_warm_start.py
+++ b/tests/test_cluster_centers_warm_start.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Tests for ClusterCentersWarmStartCallback."""
 
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock
 
 import pytest
 import torch

--- a/tests/test_co_teaching_loss.py
+++ b/tests/test_co_teaching_loss.py
@@ -3,7 +3,6 @@
 
 import pytest
 import torch
-import torch.nn.functional as F
 
 from pytorch_segmentation_models_trainer.custom_losses.co_teaching_loss import (
     CoTeachingLoss,

--- a/tests/test_comparison_plots.py
+++ b/tests/test_comparison_plots.py
@@ -8,7 +8,6 @@ import os
 import shutil
 import tempfile
 import pandas as pd
-import numpy as np
 from omegaconf import OmegaConf
 
 from pytorch_segmentation_models_trainer.tools.visualization.comparison_plots import (

--- a/tests/test_compute_dataset_stats.py
+++ b/tests/test_compute_dataset_stats.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import math
 import textwrap
 import unittest
 from pathlib import Path

--- a/tests/test_convert_dataset.py
+++ b/tests/test_convert_dataset.py
@@ -22,25 +22,17 @@
 
 import os
 import json
-import unittest
-import warnings
 from hydra import compose, initialize
-import hydra
 
 import pandas as pd
 from PIL import Image
 from parameterized import parameterized
-from pytorch_segmentation_models_trainer.dataset_loader.dataset import (
-    InstanceSegmentationDataset,
-)
 from pytorch_segmentation_models_trainer.tools.dataset_handlers.convert_dataset import (
     AbstractConversionStrategy,
-    ConversionProcessor,
     PolygonRNNDatasetConversionStrategy,
 )
 from pytorch_segmentation_models_trainer.utils.os_utils import (
     create_folder,
-    remove_folder,
 )
 from pytorch_segmentation_models_trainer.convert_ds import convert_dataset
 

--- a/tests/test_csv_to_parquet.py
+++ b/tests/test_csv_to_parquet.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import os
 import pandas as pd
 import runpy
 import unittest

--- a/tests/test_csv_windowed_dataset.py
+++ b/tests/test_csv_windowed_dataset.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
-import os
 from pathlib import Path
 import numpy as np
 import pandas as pd
 import pytest
-import torch
 from pytorch_segmentation_models_trainer.dataset_loader.dataset import (
     CSVWindowedSegmentationDataset,
 )

--- a/tests/test_csv_windowed_image_dataset.py
+++ b/tests/test_csv_windowed_image_dataset.py
@@ -3,7 +3,6 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import pytest
-import torch
 from pytorch_segmentation_models_trainer.dataset_loader.image_dataset import (
     CSVWindowedImageDataset,
 )

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -24,11 +24,8 @@ import unittest
 import warnings
 
 import hydra
-import numpy as np
-import segmentation_models_pytorch as smp
 import torch
 from hydra import compose, initialize
-from hydra.utils import instantiate
 from parameterized import parameterized
 from pytorch_segmentation_models_trainer.custom_models import models
 

--- a/tests/test_custom_models_smoke.py
+++ b/tests/test_custom_models_smoke.py
@@ -25,9 +25,6 @@ from pytorch_segmentation_models_trainer.custom_models.timm_models import (
 from pytorch_segmentation_models_trainer.custom_models.transformer_adapters import (
     ModelOutputAdapter,
 )
-from pytorch_segmentation_models_trainer.custom_models.terratorch_models import (
-    TerraTorchSegmentationWrapper,
-)
 from pytorch_segmentation_models_trainer.custom_models.unet import UNetBackbone
 from pytorch_segmentation_models_trainer.custom_models.unet_resnet import (
     UNetResNetBackbone,

--- a/tests/test_dann_method.py
+++ b/tests/test_dann_method.py
@@ -656,9 +656,6 @@ class TestDANNMethodStepMode:
 
     def test_get_lambda_da_reads_current_lambda_in_batch_mode(self):
         """DomainAdaptationModel._get_lambda_da must use _current_lambda."""
-        from pytorch_segmentation_models_trainer.domain_adaptation.schedulers import (
-            DANNScheduler,
-        )
 
         cfg = _make_da_cfg()
         model = DomainAdaptationModel(cfg)

--- a/tests/test_data_writer.py
+++ b/tests/test_data_writer.py
@@ -21,20 +21,14 @@
 """
 
 import os
-import unittest
 from unittest.mock import MagicMock, patch
-from pathlib import Path
-import warnings
 
 import geopandas
 import numpy as np
-import psycopg2
 import pyproj
 import rasterio
 from affine import Affine
-from geopandas.testing import geom_almost_equals, geom_equals
 from numpy.testing import assert_array_equal
-from parameterized import parameterized
 from pytorch_segmentation_models_trainer.tools.data_handlers.data_writer import (
     AbstractDataWriter,
     BatchVectorFileDataWriter,
@@ -42,10 +36,6 @@ from pytorch_segmentation_models_trainer.tools.data_handlers.data_writer import 
     RasterDataWriter,
     VectorDatabaseDataWriter,
     VectorFileDataWriter,
-)
-from pytorch_segmentation_models_trainer.utils.os_utils import (
-    create_folder,
-    remove_folder,
 )
 from rasterio.plot import reshape_as_raster
 from shapely.geometry import Polygon

--- a/tests/test_dataframe_utils.py
+++ b/tests/test_dataframe_utils.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
 import pandas as pd
-import pytest
-from pathlib import Path
 from pytorch_segmentation_models_trainer.utils.dataframe_utils import read_dataframe
 
 

--- a/tests/test_ddoq_dataset.py
+++ b/tests/test_ddoq_dataset.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import torch
 import pytest
-from torch.utils.data import TensorDataset, DataLoader
+from torch.utils.data import TensorDataset
 from pytorch_segmentation_models_trainer.dataset_loader.ddoq_dataset import (
     DDOQDistilledDataset,
 )

--- a/tests/test_detection_model.py
+++ b/tests/test_detection_model.py
@@ -21,27 +21,10 @@
 """
 
 import os
-import subprocess
-import unittest
-from importlib import import_module
 
-import albumentations as A
-import hydra
-import numpy as np
 import pytest
-import segmentation_models_pytorch as smp
-import torch
 from hydra import compose, initialize
 from parameterized import parameterized
-from pytorch_segmentation_models_trainer.custom_models import models as pytorch_smt_cm
-from pytorch_segmentation_models_trainer.dataset_loader.dataset import PolygonRNNDataset
-from pytorch_segmentation_models_trainer.model_loader.frame_field_model import (
-    FrameFieldModel,
-    FrameFieldSegmentationPLModel,
-)
-from pytorch_segmentation_models_trainer.model_loader.polygon_rnn_model import (
-    PolygonRNN,
-)
 from pytorch_segmentation_models_trainer.train import train
 
 from tests.utils import CustomTestCase

--- a/tests/test_direct_folder_evaluator.py
+++ b/tests/test_direct_folder_evaluator.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock, patch
 import os
 import shutil
 import tempfile
-import pandas as pd
 import numpy as np
 import rasterio
 from pathlib import Path

--- a/tests/test_domain_adaptation_model.py
+++ b/tests/test_domain_adaptation_model.py
@@ -13,16 +13,12 @@ Covers:
 
 from __future__ import annotations
 
-import os
-import tempfile
-import unittest
 from unittest.mock import MagicMock, PropertyMock, patch
 
-import pytest
 import torch
 import torch.nn as nn
 from omegaconf import OmegaConf
-from torch.utils.data import Dataset, TensorDataset
+from torch.utils.data import Dataset
 
 from pytorch_segmentation_models_trainer.domain_adaptation.base_method import (
     BaseDomainAdaptationMethod,

--- a/tests/test_dual_head.py
+++ b/tests/test_dual_head.py
@@ -41,7 +41,6 @@ from segmentation_models_pytorch.base import SegmentationHead, initialization as
 
 from pytorch_segmentation_models_trainer.custom_losses.loss import (
     DualHeadKendallLoss,
-    WeightedJMLSCEGCBLLoss,
 )
 from pytorch_segmentation_models_trainer.custom_models.upernet_dual_head import (
     UPerNetDualHead,

--- a/tests/test_edl_callbacks.py
+++ b/tests/test_edl_callbacks.py
@@ -305,7 +305,6 @@ class TestEvidentialUncertaintyVisualizationCallback(unittest.TestCase):
         fig.canvas.get_width_height.return_value = (100, 100)
 
         # Mock sys.modules for wandb
-        import sys
 
         mock_wandb = MagicMock()
         with patch.dict("sys.modules", {"wandb": mock_wandb}):
@@ -327,8 +326,6 @@ class TestEvidentialUncertaintyVisualizationCallback(unittest.TestCase):
             (100 * 100 * 3,), dtype=np.uint8
         ).tobytes()
         fig.canvas.get_width_height.return_value = (100, 100)
-
-        import sys
 
         mock_wandb = MagicMock()
         with patch.dict("sys.modules", {"wandb": mock_wandb}):

--- a/tests/test_edl_inference.py
+++ b/tests/test_edl_inference.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import numpy as np
-import pytest
 import rasterio
 import rasterio.transform
 import torch
@@ -162,7 +161,7 @@ class TestSaveUncertaintyRaster:
 
 class TestIntegrateBatch:
     def test_dict_output_integrated(self):
-        from pytorch_toolbelt.inference.tiles import ImageSlicer, TileMerger
+        from pytorch_toolbelt.inference.tiles import ImageSlicer
 
         proc = _make_processor(num_classes=K)
         tiler = ImageSlicer(
@@ -182,7 +181,7 @@ class TestIntegrateBatch:
 
     def test_plain_tensor_fallback(self):
         """When a plain tensor is passed, probs merger is used, unc is zeros."""
-        from pytorch_toolbelt.inference.tiles import ImageSlicer, TileMerger
+        from pytorch_toolbelt.inference.tiles import ImageSlicer
 
         proc = _make_processor(num_classes=K)
         tiler = ImageSlicer(

--- a/tests/test_edl_training_smoke.py
+++ b/tests/test_edl_training_smoke.py
@@ -15,9 +15,6 @@ import torch
 from omegaconf import OmegaConf
 from unittest.mock import MagicMock
 
-from pytorch_segmentation_models_trainer.custom_models.edl_wrapper import (
-    EvidentialWrapper,
-)
 from pytorch_segmentation_models_trainer.custom_callbacks.edl_callbacks import (
     EvidentialWarmupCallback,
 )

--- a/tests/test_edl_wrapper.py
+++ b/tests/test_edl_wrapper.py
@@ -6,7 +6,6 @@ All tests run on CPU and use a minimal segmentation model (2-layer CNN)
 to avoid any SMP / HuggingFace dependencies.
 """
 
-import pytest
 import torch
 import torch.nn as nn
 

--- a/tests/test_embedding_dataset.py
+++ b/tests/test_embedding_dataset.py
@@ -4,10 +4,8 @@ import tempfile
 import json
 import shutil
 from pathlib import Path
-from unittest.mock import patch
 import pandas as pd
 import torch
-import pytest
 from shapely.geometry import Point
 from pytorch_segmentation_models_trainer.dataset_loader.embedding_dataset import (
     EmbeddingDataset,

--- a/tests/test_evaluate_data.py
+++ b/tests/test_evaluate_data.py
@@ -4,7 +4,7 @@ Unit tests for evaluate_data.py
 """
 
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 from shapely.geometry import Polygon, Point
 
 from pytorch_segmentation_models_trainer.tools.evaluation.evaluate_data import (

--- a/tests/test_evaluation_config.py
+++ b/tests/test_evaluation_config.py
@@ -11,10 +11,7 @@ from pytorch_segmentation_models_trainer.config_definitions.evaluation_config im
     EvaluationDatasetConfig,
     MetricsConfig,
     OutputConfig,
-    ComparisonPlotsConfig,
     VisualizationConfig,
-    ParallelInferenceConfig,
-    LoadPredictionsConfig,
     PipelineOptionsConfig,
     EvaluationPipelineConfig,
 )

--- a/tests/test_experiments_runner.py
+++ b/tests/test_experiments_runner.py
@@ -8,10 +8,7 @@ Run with:
 
 import json
 import os
-import shutil
-import tempfile
-import unittest
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 import pytorch_lightning as pl
 from omegaconf import OmegaConf

--- a/tests/test_experiments_runner_config.py
+++ b/tests/test_experiments_runner_config.py
@@ -3,7 +3,6 @@
 Tests for experiments_runner_config dataclasses.
 """
 
-import pytest
 from omegaconf import OmegaConf
 from pytorch_segmentation_models_trainer.config_definitions.experiments_runner_config import (
     ExperimentsRunnerConfig,

--- a/tests/test_export_inference.py
+++ b/tests/test_export_inference.py
@@ -4,7 +4,7 @@ Unit tests for export_inference.py
 """
 
 import unittest
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 import numpy as np
 import os
 import shutil

--- a/tests/test_fine_tuning.py
+++ b/tests/test_fine_tuning.py
@@ -12,7 +12,6 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
-import torch
 import torch.nn as nn
 
 from pytorch_segmentation_models_trainer.fine_tuning.lora_utils import (

--- a/tests/test_fine_tuning_config.py
+++ b/tests/test_fine_tuning_config.py
@@ -5,7 +5,6 @@ Tests for fine_tuning_config dataclasses.
 
 from dataclasses import asdict
 
-import pytest
 from omegaconf import OmegaConf
 from pytorch_segmentation_models_trainer.config_definitions.fine_tuning_config import (
     LoraAdapterConfig,

--- a/tests/test_frame_field_model.py
+++ b/tests/test_frame_field_model.py
@@ -7,12 +7,10 @@ Tests for FrameFieldModel / FrameFieldSegmentationPLModel.
 """
 
 import os
-import unittest
 from importlib import import_module
 from unittest.mock import MagicMock, patch
 
 import hydra
-import numpy as np
 import pytorch_lightning as pl
 import segmentation_models_pytorch as smp
 import torch

--- a/tests/test_gpu_distributor.py
+++ b/tests/test_gpu_distributor.py
@@ -6,7 +6,6 @@ Unit tests for gpu_distributor.py
 import unittest
 from unittest.mock import MagicMock, patch
 from omegaconf import OmegaConf
-import torch
 
 from pytorch_segmentation_models_trainer.tools.evaluation.gpu_distributor import (
     GPUDistributor,

--- a/tests/test_gradient_centralization.py
+++ b/tests/test_gradient_centralization.py
@@ -21,22 +21,10 @@
 """
 
 import os
-import subprocess
-import unittest
-from importlib import import_module
 
-import hydra
-import numpy as np
-import segmentation_models_pytorch as smp
-import torch
 from hydra import compose, initialize
 from parameterized import parameterized
-from pytorch_segmentation_models_trainer.model_loader.frame_field_model import (
-    FrameFieldModel,
-    FrameFieldSegmentationPLModel,
-)
 from pytorch_segmentation_models_trainer.train import train
-from pytorch_segmentation_models_trainer.custom_models import models as pytorch_smt_cm
 
 from tests.utils import CustomTestCase
 

--- a/tests/test_huggingface_models.py
+++ b/tests/test_huggingface_models.py
@@ -10,7 +10,7 @@ with:  pip install pytorch_segmentation_models_trainer[transformers]
 """
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 import torch

--- a/tests/test_image_processing_worker.py
+++ b/tests/test_image_processing_worker.py
@@ -7,7 +7,6 @@ import numpy as np
 import rasterio
 from rasterio.transform import from_origin
 from rasterio.windows import Window
-import torch
 from unittest.mock import MagicMock, patch
 
 from pytorch_segmentation_models_trainer.tools.evaluation.image_processing_worker import (

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -23,7 +23,6 @@
 import json
 import os
 from pathlib import Path
-import warnings
 
 import albumentations as A
 import geopandas
@@ -34,7 +33,6 @@ import segmentation_models_pytorch as smp
 import torch
 from collections import OrderedDict
 from hydra import compose, initialize
-from hydra.utils import instantiate
 from parameterized import parameterized
 from pytorch_segmentation_models_trainer.custom_models.models import (
     ObjectDetectionModel,

--- a/tests/test_inference_pipeline.py
+++ b/tests/test_inference_pipeline.py
@@ -8,8 +8,6 @@ and that is_peft_model / merge_lora_weights behave correctly.
 
 from unittest.mock import MagicMock, patch
 
-import pytest
-import torch
 import torch.nn as nn
 
 from pytorch_segmentation_models_trainer.fine_tuning.lora_utils import (

--- a/tests/test_inference_processors.py
+++ b/tests/test_inference_processors.py
@@ -4,7 +4,7 @@ Unit tests for inference_processors.py
 """
 
 import unittest
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 import numpy as np
 import torch
 import rasterio
@@ -13,7 +13,6 @@ import albumentations as A
 from collections import defaultdict
 import os
 import shutil
-from pathlib import Path
 
 from pytorch_segmentation_models_trainer.tools.inference.inference_processors import (
     AbstractInferenceProcessor,
@@ -26,11 +25,6 @@ from pytorch_segmentation_models_trainer.tools.polygonization.polygonizer import
 from pytorch_segmentation_models_trainer.tools.inference.export_inference import (
     RasterExportInferenceStrategy,
 )
-from pytorch_toolbelt.utils.torch_utils import (
-    image_to_tensor,
-    to_numpy,
-)
-from torch.utils.data import DataLoader
 from pytorch_toolbelt.inference.tiles import ImageSlicer, TileMerger
 
 

--- a/tests/test_inference_service.py
+++ b/tests/test_inference_service.py
@@ -22,21 +22,14 @@
 
 from collections import OrderedDict
 import os
-from pathlib import Path
 from unittest.mock import Mock
-import warnings
 
 # from unittest import IsolatedAsyncioTestCase
 
-import albumentations as A
 import hydra
-import numpy as np
-import rasterio
-import segmentation_models_pytorch as smp
 import torch
 from fastapi.testclient import TestClient
 from hydra import compose, initialize
-from hydra.utils import instantiate
 from parameterized import parameterized
 from pytorch_segmentation_models_trainer.model_loader.frame_field_model import (
     FrameFieldSegmentationPLModel,

--- a/tests/test_kl_annealing.py
+++ b/tests/test_kl_annealing.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import math
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/test_kmeans.py
+++ b/tests/test_kmeans.py
@@ -4,7 +4,6 @@ import torch
 import numpy as np
 import tempfile
 from unittest.mock import patch
-from sklearn.cluster import MiniBatchKMeans as SklearnMiniBatchKMeans
 from sklearn.metrics import adjusted_rand_score
 from torch.utils.data import Dataset, DataLoader
 from pytorch_segmentation_models_trainer.tools.kmeans.kmeans_calculator import (

--- a/tests/test_loss_builder.py
+++ b/tests/test_loss_builder.py
@@ -4,7 +4,7 @@ Unit tests for loss_builder.py
 """
 
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import torch
 import torch.nn as nn

--- a/tests/test_loss_config_definition.py
+++ b/tests/test_loss_config_definition.py
@@ -5,7 +5,7 @@ Tests for loss_config_definition dataclasses.
 
 import pytest
 from omegaconf import OmegaConf, MissingMandatoryValue
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 from pytorch_segmentation_models_trainer.config_definitions.loss_config_definition import (
     SegParamsConfig,
     BaseLossConfig,

--- a/tests/test_losses_callbacks_tta.py
+++ b/tests/test_losses_callbacks_tta.py
@@ -20,7 +20,7 @@ import pytorch_segmentation_models_trainer  # noqa: F401
 
 import torch
 import torch.nn as nn
-from unittest.mock import Mock, MagicMock
+from unittest.mock import Mock
 
 from pytorch_segmentation_models_trainer.custom_losses.loss import (
     _lovasz_grad,
@@ -792,7 +792,6 @@ class TestLLRD(unittest.TestCase):
 
     def test_param_groups_have_correct_lr_ordering(self):
         """Decoder LR > stage 3 LR > stage 2 LR > ... > stem LR."""
-        from pytorch_segmentation_models_trainer.model_loader.model import Model
 
         model = _ConvNeXtLikeModel()
         # Call the static method directly by creating a mock Model instance
@@ -880,7 +879,6 @@ class TestLLRD(unittest.TestCase):
     def test_no_weight_decay_for_1d_params(self):
         """Bias and normalization parameters (1-D) should have weight_decay=0."""
         model = _ConvNeXtLikeModel()
-        import re
 
         base_lr = 1e-4
         layer_decay = 0.9

--- a/tests/test_lulc_input_dataset.py
+++ b/tests/test_lulc_input_dataset.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 """Tests for LulcInputDataset and LulcInputWindowedDataset."""
 
-import os
-import tempfile
-
 import numpy as np
 import pandas as pd
 import pytest

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 from omegaconf import OmegaConf
 from pytorch_segmentation_models_trainer.main import main
 

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -21,13 +21,9 @@
 """
 
 import os
-from typing import Any, Callable, List, Tuple
+from typing import Callable, List, Tuple
 import unittest
-from shapely.geometry.base import BaseGeometry
-import torch
-import geopandas
 import json
-import numpy as np
 from shapely.geometry import Polygon, Point
 from parameterized import parameterized
 

--- a/tests/test_mbtiles_crops_dataset.py
+++ b/tests/test_mbtiles_crops_dataset.py
@@ -494,7 +494,6 @@ class TestVectorCrops:
         """Vector file in EPSG:3857 is reprojected to image CRS."""
         import geopandas as gpd
         from shapely.geometry import box as shapely_box
-        from rasterio.crs import CRS as RioCRS
 
         img, mask = raster_pair
         # Build box in EPSG:3857 at Q0 centre

--- a/tests/test_mbtiles_multiclass_mask_builder.py
+++ b/tests/test_mbtiles_multiclass_mask_builder.py
@@ -552,8 +552,6 @@ def test_frame_identifier_missing_attribute_returns_index_default():
         == "frame_00003"
     )
 
-    import math
-
     frame_nan = pd.Series({"rect_id": float("nan")})
     assert (
         multiclass_mask_builder._frame_identifier(frame_nan, "rect_id", 5)
@@ -778,7 +776,6 @@ def test_build_mbtiles_raises_when_reference_has_no_crs(tmp_path, monkeypatch):
     reference_path, frames_path, vector_path = _build_fixture_data(tmp_path)
 
     import rasterio as _rasterio
-    from unittest.mock import MagicMock
 
     orig_open = _rasterio.open
     _open_calls = []

--- a/tests/test_mc_dropout.py
+++ b/tests/test_mc_dropout.py
@@ -8,7 +8,7 @@ All tests run on CPU with minimal models to avoid heavy dependencies.
 import math
 import warnings
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -23,9 +23,8 @@
 import unittest
 import torch
 import numpy as np
-import json
 import shapely.wkt
-from shapely.geometry import Polygon, Point
+from shapely.geometry import Polygon
 
 from pytorch_segmentation_models_trainer.custom_metrics import metrics
 

--- a/tests/test_metrics_calculator.py
+++ b/tests/test_metrics_calculator.py
@@ -4,15 +4,14 @@ Unit tests for metrics_calculator.py
 """
 
 import unittest
-from unittest.mock import MagicMock, patch, mock_open
+from unittest.mock import MagicMock, patch
 import numpy as np
 import pandas as pd
 import torch
 import rasterio
 from rasterio.transform import Affine
 from rasterio.windows import Window
-from omegaconf import OmegaConf, DictConfig
-import json
+from omegaconf import OmegaConf
 import os
 from pathlib import Path
 
@@ -22,9 +21,6 @@ from pytorch_segmentation_models_trainer.tools.evaluation.metrics_calculator imp
 )
 from pytorch_segmentation_models_trainer.tools.evaluation.image_processing_worker import (
     process_single_image_worker,
-)
-from pytorch_segmentation_models_trainer.tools.data_handlers.raster_reader import (
-    RasterFile,
 )
 
 

--- a/tests/test_metrics_callbacks.py
+++ b/tests/test_metrics_callbacks.py
@@ -10,7 +10,6 @@ import torch
 import os
 import shutil
 import tempfile
-from pathlib import Path
 
 from pytorch_segmentation_models_trainer.custom_callbacks.metrics_callbacks import (
     ConfusionMatrixCallback,

--- a/tests/test_mod_polygonrnn.py
+++ b/tests/test_mod_polygonrnn.py
@@ -21,35 +21,17 @@
 """
 
 import os
-import subprocess
 from typing import Dict, Optional
 import unittest
-from importlib import import_module
 
 import albumentations as A
 from albumentations.pytorch.transforms import ToTensorV2
-import hydra
 import numpy as np
-from pytorch_lightning import Trainer
-import segmentation_models_pytorch as smp
 import torch
-from hydra import compose, initialize
 from parameterized import parameterized
-from pytorch_segmentation_models_trainer.custom_models import models as pytorch_smt_cm
 from pytorch_segmentation_models_trainer.dataset_loader.dataset import (
-    ModPolyMapperDataset,
     ObjectDetectionDataset,
     PolygonRNNDataset,
-)
-from pytorch_segmentation_models_trainer.model_loader.frame_field_model import (
-    FrameFieldModel,
-    FrameFieldSegmentationPLModel,
-)
-from pytorch_segmentation_models_trainer.model_loader.mod_polymapper import (
-    GenericPolyMapperPLModel,
-)
-from pytorch_segmentation_models_trainer.model_loader.polygon_rnn_model import (
-    PolygonRNN,
 )
 from pytorch_segmentation_models_trainer.custom_models.mod_polymapper.modpolymapper import (
     ModPolyMapper,
@@ -57,9 +39,7 @@ from pytorch_segmentation_models_trainer.custom_models.mod_polymapper.modpolymap
 from pytorch_segmentation_models_trainer.train import train
 from pytorch_segmentation_models_trainer.utils import polygonrnn_utils
 
-from tests.utils import BasicTestCase, CustomTestCase, get_config_from_hydra
-
-from unittest.mock import MagicMock, Mock, patch
+from tests.utils import BasicTestCase, get_config_from_hydra
 
 current_dir = os.path.dirname(__file__)
 detection_root_dir = os.path.join(

--- a/tests/test_model_methods.py
+++ b/tests/test_model_methods.py
@@ -555,7 +555,6 @@ class TestZeroInitExtraInputChannels:
 
     def test_get_model_applies_zero_init_when_flag_set(self):
         """get_model() with zero_init_extra_input_channels=true zeroes extra channels."""
-        import segmentation_models_pytorch as smp
         from omegaconf import OmegaConf
         from pytorch_segmentation_models_trainer.model_loader.model import Model
 

--- a/tests/test_model_sliding_window.py
+++ b/tests/test_model_sliding_window.py
@@ -10,8 +10,7 @@ Tests for sliding-window test-phase methods added to Model:
 """
 
 import tempfile
-from pathlib import Path
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch

--- a/tests/test_model_test_dataset.py
+++ b/tests/test_model_test_dataset.py
@@ -10,12 +10,9 @@ Covers:
   - test_step() loss value, logging keys, compound loss, metrics
 """
 
-import logging
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock
 
-import pytest
 import torch
-import torch.nn as nn
 from omegaconf import OmegaConf
 from torch.utils.data import TensorDataset
 

--- a/tests/test_model_training_step.py
+++ b/tests/test_model_training_step.py
@@ -7,12 +7,10 @@ and end-to-end training/validation steps with a lightweight SMP model.
 """
 
 import logging
-from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 import torch
-import torch.nn as nn
 from omegaconf import OmegaConf
 
 from pytorch_segmentation_models_trainer.model_loader.model import Model

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import torch
 import torch.nn as nn
 import unittest
 from pytorch_segmentation_models_trainer.utils.model_utils import (

--- a/tests/test_monitor_callback.py
+++ b/tests/test_monitor_callback.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-import logging
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import torch
 import torch.nn as nn

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -20,9 +20,6 @@
  ****
 """
 
-import os
-import subprocess
-
 import pytorch_lightning as pl
 from hydra import compose, initialize
 from parameterized import parameterized

--- a/tests/test_optuna_runner.py
+++ b/tests/test_optuna_runner.py
@@ -3,11 +3,8 @@
 
 import json
 import os
-import secrets
-import tempfile
-from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
-from unittest.mock import MagicMock, call, patch
+from typing import List, Optional
+from unittest.mock import MagicMock, patch
 
 import optuna
 import pytest

--- a/tests/test_os_utils.py
+++ b/tests/test_os_utils.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
 import unittest
-from pathlib import Path
 from tempfile import TemporaryDirectory
 from pytorch_segmentation_models_trainer.utils.os_utils import (
     remove_folder,

--- a/tests/test_polygon_utils.py
+++ b/tests/test_polygon_utils.py
@@ -14,7 +14,6 @@ from shapely.geometry import (
     Polygon,
     MultiPolygon,
 )
-import rasterio
 from rasterio.transform import Affine
 import matplotlib.pyplot as plt
 import torch

--- a/tests/test_polygonizer.py
+++ b/tests/test_polygonizer.py
@@ -21,8 +21,6 @@
 """
 
 import os
-import unittest
-import warnings
 from dataclasses import dataclass, field
 from unittest.mock import MagicMock
 
@@ -30,9 +28,7 @@ import geopandas
 import hydra
 import rasterio
 import torch
-import numpy as np
 from shapely.geometry import Polygon
-from geopandas.testing import geom_almost_equals as _geom_almost_equals
 
 
 def geom_almost_equals(this, that, tolerance=0.01):
@@ -92,10 +88,6 @@ from pytorch_segmentation_models_trainer.tools.polygonization.polygonizer import
     SimplePolygonizerProcessor,
 )
 from pytorch_segmentation_models_trainer.utils import frame_field_utils, seed_utils
-from pytorch_segmentation_models_trainer.utils.os_utils import (
-    create_folder,
-    remove_folder,
-)
 
 current_dir = os.path.dirname(__file__)
 root_dir = os.path.join(current_dir, "testing_data")

--- a/tests/test_polygonrnn_model.py
+++ b/tests/test_polygonrnn_model.py
@@ -21,24 +21,12 @@
 """
 
 import os
-import subprocess
-import unittest
-from importlib import import_module
 
 import albumentations as A
 from albumentations.pytorch.transforms import ToTensorV2
-import hydra
-import numpy as np
-import segmentation_models_pytorch as smp
 import torch
 from hydra import compose, initialize
-from parameterized import parameterized
-from pytorch_segmentation_models_trainer.custom_models import models as pytorch_smt_cm
 from pytorch_segmentation_models_trainer.dataset_loader.dataset import PolygonRNNDataset
-from pytorch_segmentation_models_trainer.model_loader.frame_field_model import (
-    FrameFieldModel,
-    FrameFieldSegmentationPLModel,
-)
 from pytorch_segmentation_models_trainer.model_loader.polygon_rnn_model import (
     PolygonRNN,
 )

--- a/tests/test_polygonrnn_utils.py
+++ b/tests/test_polygonrnn_utils.py
@@ -21,30 +21,14 @@
 """
 
 import os
-import subprocess
 import unittest
-from importlib import import_module
 from unittest.mock import patch
 
-import albumentations as A
-import hydra
 import numpy as np
-import segmentation_models_pytorch as smp
 import shapely
 import shapely.geometry
 import torch
-from hydra import compose, initialize
 from parameterized import parameterized
-from pytorch_segmentation_models_trainer.custom_models import models as pytorch_smt_cm
-from pytorch_segmentation_models_trainer.dataset_loader.dataset import PolygonRNNDataset
-from pytorch_segmentation_models_trainer.model_loader.frame_field_model import (
-    FrameFieldModel,
-    FrameFieldSegmentationPLModel,
-)
-from pytorch_segmentation_models_trainer.model_loader.polygon_rnn_model import (
-    PolygonRNN,
-)
-from pytorch_segmentation_models_trainer.train import train
 from pytorch_segmentation_models_trainer.utils import polygonrnn_utils
 
 current_dir = os.path.dirname(__file__)

--- a/tests/test_postgres_reader.py
+++ b/tests/test_postgres_reader.py
@@ -169,7 +169,6 @@ def test_read_tiles_class_dist_already_dict():
 
 def _raw_df_with_embedding() -> pd.DataFrame:
     """Raw DataFrame with embedding column as list (psycopg2 + pgvector adapter)."""
-    import numpy as np
 
     df = _raw_df()
     df["embedding"] = [

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -21,8 +21,6 @@
 """
 
 import os
-from pathlib import Path
-import warnings
 from unittest.mock import MagicMock, patch
 
 import hydra

--- a/tests/test_raster_patch_dataset.py
+++ b/tests/test_raster_patch_dataset.py
@@ -19,7 +19,6 @@
  ****
 """
 
-import os
 import warnings
 from pathlib import Path
 
@@ -547,8 +546,6 @@ class TestRasterPatchDataset(BasicTestCase):
 
     def test_reset_augmentation_function_returns_valid_output(self):
         """reset_augmentation_function=True still returns correctly shaped tensors."""
-        import albumentations as A
-        from albumentations.pytorch import ToTensorV2
 
         aug = [
             {"_target_": "albumentations.HorizontalFlip", "p": 0.0},

--- a/tests/test_raster_reader.py
+++ b/tests/test_raster_reader.py
@@ -21,8 +21,6 @@
 """
 
 import os
-import unittest
-import warnings
 
 import numpy as np
 import geopandas as gpd
@@ -37,14 +35,10 @@ from pytorch_segmentation_models_trainer.tools.data_handlers.raster_reader impor
     SingleImageReaderProcessor,
     save_with_rasterio,
 )
-from pytorch_segmentation_models_trainer.tools.data_handlers.vector_reader import (
-    GeomTypeEnum,
-)
 from shapely.geometry import box
 from pytorch_segmentation_models_trainer.utils.os_utils import (
     create_folder,
     hash_file,
-    remove_folder,
 )
 
 current_dir = os.path.dirname(__file__)

--- a/tests/test_results_aggregator.py
+++ b/tests/test_results_aggregator.py
@@ -8,7 +8,7 @@ import os
 import json
 import pandas as pd
 import numpy as np
-from omegaconf import OmegaConf, DictConfig
+from omegaconf import OmegaConf
 import shutil
 
 from pytorch_segmentation_models_trainer.tools.evaluation.results_aggregator import (

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -22,13 +22,9 @@
 
 import os
 import subprocess
-from typing import List
 
 import pytest
-import pytorch_lightning as pl
 from parameterized import parameterized
-from hydra import compose, initialize
-from pytorch_segmentation_models_trainer.train import train
 
 from tests.utils import CustomTestCase
 

--- a/tests/test_seed_utils.py
+++ b/tests/test_seed_utils.py
@@ -272,11 +272,7 @@ class TestSeedIntegrationEndToEnd(BasicTestCase):
     def test_dataloader_determinism_with_augmentation(self):
         """Verifies that the same seed produces the same augmented batches."""
         from omegaconf import OmegaConf
-        import albumentations as A
         from pytorch_segmentation_models_trainer.model_loader.model import Model
-        from pytorch_segmentation_models_trainer.dataset_loader.image_dataset import (
-            ImageDataset,
-        )
         import pandas as pd
         import numpy as np
 

--- a/tests/test_sliding_window_core.py
+++ b/tests/test_sliding_window_core.py
@@ -8,14 +8,12 @@ All tests run on CPU with minimal dummy models and synthetic tensors.
 import os
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock, patch, call
 import warnings
 
 import numpy as np
 import pytest
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 
 from pytorch_segmentation_models_trainer.tools.inference.sliding_window import (
     SlidingWindowCore,

--- a/tests/test_soft_label_loss.py
+++ b/tests/test_soft_label_loss.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """Tests for SoftLabelWeightedCELoss."""
 
-import pytest
 import torch
 
 from pytorch_segmentation_models_trainer.custom_losses.soft_label_loss import (

--- a/tests/test_soft_label_model.py
+++ b/tests/test_soft_label_model.py
@@ -1,17 +1,12 @@
 # -*- coding: utf-8 -*-
 """Tests for SoftLabelModel._shared_step dict-unwrap and _compute_loss re-wrap."""
 
-import pytest
 import torch
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 from pytorch_segmentation_models_trainer.model_loader.soft_label_model import (
     SoftLabelModel,
 )
-from pytorch_segmentation_models_trainer.custom_losses.soft_label_loss import (
-    SoftLabelWeightedCELoss,
-)
-from pytorch_segmentation_models_trainer.custom_losses.base_loss import MultiLoss
 
 B, C, H, W = 2, 4, 8, 8
 

--- a/tests/test_spatial_kfold.py
+++ b/tests/test_spatial_kfold.py
@@ -6,12 +6,10 @@ Run with:
     python -m pytest tests/test_spatial_kfold.py -v --tb=short
 """
 
-import os
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
-import pytest
 import rasterio
 from rasterio.transform import from_bounds
 

--- a/tests/test_student_model.py
+++ b/tests/test_student_model.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 import torch
 import torch.nn as nn
 from omegaconf import OmegaConf

--- a/tests/test_tensor_utils.py
+++ b/tests/test_tensor_utils.py
@@ -21,16 +21,10 @@
 """
 
 import os
-import warnings
 
 import numpy as np
-import skan
 import torch
-import matplotlib.pyplot as plt
-from matplotlib.testing.compare import compare_images
-from parameterized.parameterized import parameterized
 from pytorch_segmentation_models_trainer.utils.tensor_utils import (
-    TensorPoly,
     polygons_to_tensorpoly,
     tensorpoly_pad,
     SpatialGradient,

--- a/tests/test_terratorch_models.py
+++ b/tests/test_terratorch_models.py
@@ -6,7 +6,6 @@ TerraTorch is mocked so these tests run without installing terratorch.
 The _prepare_input helper and head wiring are tested with a fake backbone.
 """
 
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/test_tile_dataset_builder.py
+++ b/tests/test_tile_dataset_builder.py
@@ -6,10 +6,8 @@ from pathlib import Path
 
 import geopandas as gpd
 import numpy as np
-import pandas as pd
 import pytest
 import rasterio
-from rasterio.crs import CRS
 from rasterio.transform import from_bounds
 from shapely.geometry import box
 

--- a/tests/test_tools_config_def.py
+++ b/tests/test_tools_config_def.py
@@ -23,16 +23,9 @@ from pytorch_segmentation_models_trainer.config_definitions.tools_config_def imp
     VectorFileExportInferenceStrategyConfig,
     VectorDatabaseExportInferenceStrategyConfig,
     ObjectDetectionExportInferenceStrategyConfig,
-    InnerPolylinesParamsConfig,
-    SimplePolConfigConfig,
     SimplePolygonizerProcessorConfig,
-    ACMConfigConfig,
     ACMPolygonizerProcessorConfig,
-    LossParamsCoefsConfig,
-    LossParamsConfig,
-    ASMConfigConfig,
     ASMPolygonizerProcessorConfig,
-    PolygonRNNConfigConfig,
     PolygonRNNPolygonizerProcessorConfig,
 )
 

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -6,7 +6,6 @@ Refactored to mock Trainer.fit() and Model.setup() so tests don't run
 actual training pipelines (I/O, GPU, etc.).
 """
 
-import os
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/test_train_config.py
+++ b/tests/test_train_config.py
@@ -4,9 +4,7 @@ Tests for train_config dataclasses.
 """
 
 import pytest
-from unittest.mock import MagicMock, patch
 from omegaconf import OmegaConf, MissingMandatoryValue
-import dataclasses
 
 from pytorch_segmentation_models_trainer.config_definitions.train_config import (
     BackboneConfig,

--- a/tests/test_training_callbacks.py
+++ b/tests/test_training_callbacks.py
@@ -6,9 +6,6 @@ import unittest
 from unittest.mock import MagicMock, patch
 import torch
 import torch.nn as nn
-import numpy as np
-import pytorch_lightning as pl
-from pathlib import Path
 
 from pytorch_segmentation_models_trainer.custom_callbacks.training_callbacks import (
     WarmupCallback,

--- a/tests/test_tta.py
+++ b/tests/test_tta.py
@@ -25,9 +25,7 @@ import torch
 from pytorch_segmentation_models_trainer.tools.tta.tta import (
     D4_AUGMENTATIONS,
     FLIP_H,
-    FLIP_H_ROT90,
     FLIP_V,
-    FLIP_V_ROT90,
     ROT0,
     ROT180,
     ROT270,

--- a/tests/test_validate_evaluation_config.py
+++ b/tests/test_validate_evaluation_config.py
@@ -5,7 +5,7 @@ Unit tests for validate_evaluation_config.py
 
 import unittest
 from unittest.mock import MagicMock, patch
-from omegaconf import DictConfig, OmegaConf
+from omegaconf import OmegaConf
 import runpy
 import sys
 import types

--- a/tests/test_variational_autoencoder.py
+++ b/tests/test_variational_autoencoder.py
@@ -909,7 +909,7 @@ def test_vae_logvar_clamp_default_is_none():
 
 
 def test_variational_autoencoder_model_computes_metrics_when_configured():
-    import torchmetrics
+    pass
 
     cfg = OmegaConf.create(
         {

--- a/tests/test_vector_reader.py
+++ b/tests/test_vector_reader.py
@@ -25,7 +25,7 @@ import runpy
 import unittest
 from pathlib import Path
 import warnings
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import geopandas
 from geopandas.testing import geom_equals, geom_almost_equals

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -21,7 +21,6 @@
 """
 
 import os
-import warnings
 
 import hydra
 import matplotlib.pyplot as plt


### PR DESCRIPTION
## Summary
Addresses the "unused imports" code-quality finding surfaced under **Security > Code quality**.

- `flake8 --select=F401` found ~358 hits across 145 files (77 framework, 280 tests, 1 script), mostly leftovers from past refactors.
- Applied via `autoflake --remove-all-unused-imports`.
- Before running it, fixed the 4 legitimate false positives: submodule re-exports in `__init__.py` (`pytorch_segmentation_models_trainer`, `utils`, `tools/mbtiles`) that exist for their side effect of exposing the submodule on the parent package — those now declare `__all__` instead of relying on a bare "unused" import.

## Verification
- `flake8 --select=F401,F821,E9` clean repo-wide.
- Full test suite (excluding the documented segfault/network/subprocess exclusions): **3583 passed, 5 failed, 8 skipped**. The 5 failures are a pre-existing local env gap (`transformers` not installed in this dev venv — same gap already documented for `test_embedding_extractor.py`); reproduced identically on `main` before this change, confirmed not a regression. CI's dedicated `test-transformers` job has that dependency installed.

## CHANGELOG
Not user-facing behavior — pure internal cleanup, no CHANGELOG entry per repo convention (no functional change to document).

🤖 Generated with [Claude Code](https://claude.com/claude-code)